### PR TITLE
Add Source Attribute to Submission Model

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -9,7 +9,7 @@ class Submission < ActiveRecord::Base
   end
 
   def self.all_with_average_score
-    fields = ['id', 'candidate_name', 'candidate_email', 'email_text', 'zipfile', 'active', 'language_id', 'level_id', 'created_at', 'updated_at']
+    fields = ['id', 'candidate_name', 'candidate_email', 'email_text', 'zipfile', 'active', 'language_id', 'level_id', 'created_at', 'updated_at', 'source']
     submission_fields = fields.map { |f| 'submissions.' + f }.join(',')
     avg = ', round(avg(assessments.score) * 2) / 2 as average_score'
     select(submission_fields + avg).joins('LEFT JOIN assessments ON (assessments.submission_id = submissions.id)').group(submission_fields).order(updated_at: :desc)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -40,6 +40,7 @@ class Submission < ActiveRecord::Base
       candidate_email: submission.fetch(:candidate_email),
       email_text: submission.fetch(:email_text), 
       level: level, 
-      language: language)
+      language: language,
+      source: submission.fetch(:source))
   end
 end

--- a/app/serializers/submission_serializer.rb
+++ b/app/serializers/submission_serializer.rb
@@ -1,6 +1,6 @@
 class SubmissionSerializer < ActiveModel::Serializer
   embed :ids, include: true
-  attributes :id, :candidate_name, :candidate_email, :email_text, :zipfile, :created_at, :updated_at, :active, :average_score
+  attributes :id, :candidate_name, :candidate_email, :email_text, :zipfile, :created_at, :updated_at, :active, :average_score, :source
   has_one :language
   has_one :level
 

--- a/db/migrate/20150309153149_add_source_attribute_to_submissions.rb
+++ b/db/migrate/20150309153149_add_source_attribute_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddSourceAttributeToSubmissions < ActiveRecord::Migration
+  def change
+    add_column :submissions, :source, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140911205423) do
+ActiveRecord::Schema.define(version: 20150309153149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,13 @@ ActiveRecord::Schema.define(version: 20140911205423) do
     t.datetime "updated_at"
     t.boolean  "published",     default: true
     t.boolean  "exemplary",     default: false
+  end
+
+  create_table "cons", force: true do |t|
+    t.string   "text"
+    t.integer  "assessment_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "languages", force: true do |t|
@@ -42,6 +49,13 @@ ActiveRecord::Schema.define(version: 20140911205423) do
   create_table "pages", force: true do |t|
     t.string   "name"
     t.text     "raw_text"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "pros", force: true do |t|
+    t.string   "text"
+    t.integer  "assessment_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -70,6 +84,7 @@ ActiveRecord::Schema.define(version: 20140911205423) do
     t.string   "candidate_email"
     t.integer  "level_id"
     t.string   "zipfile"
+    t.string   "source"
   end
 
   create_table "users", force: true do |t|

--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -27,7 +27,7 @@ describe AnalyticsController do
         let(:language) { Language.find_by_name('Java') }
         let(:level) { Level.find_by_text('Junior') }
         let!(:submission) { Submission.create({email_text: 'test', language: language, candidate_name: 'Bob', candidate_email: 'bob@example.com', level: level}) }
-        let(:expected) { [{email_text: 'test', zipfile: nil, average_score: nil, active: true, language_id: language.id, level_id: level.id, candidate_name: 'Bob', candidate_email: 'bob@example.com'}].to_json }
+        let(:expected) { [{email_text: 'test', zipfile: nil, average_score: nil, active: true, language_id: language.id, level_id: level.id, candidate_name: 'Bob', candidate_email: 'bob@example.com', source: nil}].to_json }
 
         subject(:body) { response.body }
 
@@ -41,8 +41,8 @@ describe AnalyticsController do
         let(:level) { Level.find_by_text('Junior') }
         let!(:submission) { Submission.create({email_text: 'test1', language: language, candidate_name: 'Submission One', candidate_email: 'bob@example.com', level: level}) }
         let!(:submission2) { Submission.create({email_text: 'test2', language: language, candidate_name: 'Submission Two', candidate_email: 'bob@example.com', level: level}) }
-        let(:expected) { [{email_text: 'test2', zipfile: nil, active: true, average_score: nil, language_id: language.id, level_id: level.id, candidate_name: 'Submission Two', candidate_email: 'bob@example.com'},
-                          {email_text: 'test1', zipfile: nil, active: true, average_score: nil, language_id: language.id, level_id: level.id, candidate_name: 'Submission One', candidate_email: 'bob@example.com'}].to_json }
+        let(:expected) { [{email_text: 'test2', zipfile: nil, active: true, average_score: nil, language_id: language.id, level_id: level.id, candidate_name: 'Submission Two', candidate_email: 'bob@example.com', source: nil},
+                          {email_text: 'test1', zipfile: nil, active: true, average_score: nil, language_id: language.id, level_id: level.id, candidate_name: 'Submission One', candidate_email: 'bob@example.com', source: nil}].to_json }
 
         subject(:body) { response.body }
 

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -27,7 +27,7 @@ describe SubmissionsController do
         let(:language) { Language.find_by_name('Java') }
         let(:level) { Level.find_by_text('Junior') }
         let!(:submission) { Submission.create({email_text: 'test', language: language, candidate_name: 'Bob', candidate_email: 'bob@example.com', level: level}) }
-        let(:expected) { [{email_text: 'test', zipfile: nil, average_score: nil, active: true, language_id: language.id, level_id: level.id, candidate_name: 'Bob', candidate_email: 'bob@example.com'}].to_json }
+        let(:expected) { [{email_text: 'test', zipfile: nil, average_score: nil, active: true, language_id: language.id, level_id: level.id, candidate_name: 'Bob', candidate_email: 'bob@example.com', source: nil }].to_json }
 
         subject(:body) { response.body }
 
@@ -41,7 +41,7 @@ describe SubmissionsController do
         let!(:submission) { Submission.create({email_text: 'test', candidate_name: 'Bob', candidate_email: 'bob@example.com'}) }
         let!(:assessment1) { Assessment.create({submission: submission, score: 3}) }
         let!(:assessment2) { Assessment.create({submission: submission, score: 4}) }
-        let(:expected) { [{email_text: 'test', zipfile: nil, average_score: '3.5', active: true, language_id: nil, level_id: nil, candidate_name: 'Bob', candidate_email: 'bob@example.com'}].to_json }
+        let(:expected) { [{email_text: 'test', zipfile: nil, average_score: '3.5', active: true, language_id: nil, level_id: nil, candidate_name: 'Bob', candidate_email: 'bob@example.com', source: nil}].to_json }
         subject(:body) { response.body }
 
         it { should be_json_eql(expected).at_path('submissions') }
@@ -52,8 +52,8 @@ describe SubmissionsController do
         let(:level) { Level.find_by_text('Junior') }
         let!(:submission) { Submission.create({email_text: 'test1', language: language, candidate_name: 'Submission One', candidate_email: 'bob@example.com', level: level}) }
         let!(:submission2) { Submission.create({email_text: 'test2', language: language, candidate_name: 'Submission Two', candidate_email: 'bob@example.com', level: level}) }
-        let(:expected) { [{email_text: 'test2', zipfile: nil, active: true, average_score: nil, language_id: language.id, level_id: level.id, candidate_name: 'Submission Two', candidate_email: 'bob@example.com'},
-                          {email_text: 'test1', zipfile: nil, active: true, average_score: nil, language_id: language.id, level_id: level.id, candidate_name: 'Submission One', candidate_email: 'bob@example.com'}].to_json }
+        let(:expected) { [{email_text: 'test2', zipfile: nil, active: true, average_score: nil, language_id: language.id, level_id: level.id, candidate_name: 'Submission Two', candidate_email: 'bob@example.com', source: nil},
+                          {email_text: 'test1', zipfile: nil, active: true, average_score: nil, language_id: language.id, level_id: level.id, candidate_name: 'Submission One', candidate_email: 'bob@example.com', source: nil}].to_json }
 
         subject(:body) { response.body }
 
@@ -109,7 +109,7 @@ describe SubmissionsController do
       let!(:submission1) { Submission.create({email_text: 'first'}) }
       let!(:submission2) { Submission.create({email_text: 'second'}) }
       let(:params) { {id: submission2.id} }
-      let(:expected) { {email_text: 'second', zipfile: nil, active: true, average_score: nil, language_id: nil, candidate_name: nil, candidate_email: nil, level_id: nil}.to_json }
+      let(:expected) { {email_text: 'second', zipfile: nil, active: true, average_score: nil, language_id: nil, candidate_name: nil, candidate_email: nil, level_id: nil, source: nil}.to_json }
 
       it { should be_ok }
       its(:body) { should be_json_eql(expected).at_path('submission') }
@@ -129,7 +129,7 @@ describe SubmissionsController do
         before { add_user_to_session(role) }
 
         context 'when updating an existing submission' do
-          let(:expected) { {email_text: 'updated', average_score: nil, zipfile: nil, active: false, language_id: nil, candidate_name: nil, candidate_email: nil, level_id: nil}.to_json }
+          let(:expected) { {email_text: 'updated', average_score: nil, zipfile: nil, active: false, language_id: nil, candidate_name: nil, candidate_email: nil, level_id: nil, source: nil}.to_json }
 
           it { should be_ok }
           its(:body) { should be_json_eql(expected).at_path('submission') }

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -55,7 +55,8 @@ describe Submission do
       candidate_name: 'Bob',
       candidate_email: 'bob@example.com',
       level_id: level.id, 
-      language_id: language.id
+      language_id: language.id,
+      source: 'LinkedIn'
     }}}
 
     subject(:creation) { Submission.create_from_json(params[:submission]) }
@@ -70,6 +71,7 @@ describe Submission do
     its(:candidate_email) { should eq 'bob@example.com' }
     its('level.text') { should eq level.text }
     its('language.name') { should eq language.name }
+    its(:source) { should eq 'LinkedIn' }
   end
 
   describe '#close' do


### PR DESCRIPTION
This adds a migration to add a 'source' attribute to the Submission model so that Rebecca can more easily keep track of where Candidates are being referred from. Also modifies the serializer that sends the Model data to the Ember app so that the source attribute comes through on the front end. Lastly updates a number of the controller tests to account for Submission's new source attribute. 