### PR TITLE
Return Average Assessment for Published Assessments Only

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -9,32 +9,10 @@ class Submission < ActiveRecord::Base
   end
 
   def self.all_with_average_score
-    # fields = ['id', 'candidate_name', 'candidate_email', 'email_text', 'zipfile', 'active', 'language_id', 'level_id', 'created_at', 'updated_at', 'source']
-    # submission_fields = fields.map { |f| 'submissions.' + f }.join(',')
-    # avg = ', round(avg(assessments.score) * 2) / 2 as average_score'
-    # select(submission_fields + avg).joins('LEFT JOIN assessments ON (assessments.submission_id = submissions.id)').group(submission_fields).order(updated_at: :desc)
-    submissions_array = []
-    Submission.all.each do |submission|
-      submission_hash = submission.as_json
-      submission_hash[:average_score] = submission.average_published_assessment_score
-      submissions_array.push(submission_hash)
-      puts submission_hash
-    end
-    submissions_array
-  end
-
-  def average_published_assessment_score 
-    score_sum = 0
-    total_scores = 0
-    assessments.each do  |assessment|
-      if assessment.published 
-        score_sum += assessment.score
-        total_scores += 1
-      end
-    end
-    if total_scores != 0
-      score_sum / total_scores
-    end
+    fields = ['id', 'candidate_name', 'candidate_email', 'email_text', 'zipfile', 'active', 'language_id', 'level_id', 'created_at', 'updated_at', 'source']
+    submission_fields = fields.map { |f| 'submissions.' + f }.join(',')
+    avg = ', round(avg(assessments.score) * 2) / 2 as average_score'
+    select(submission_fields + avg).joins('LEFT JOIN assessments ON (assessments.submission_id = submissions.id AND assessments.published = TRUE)').group(submission_fields).order(updated_at: :desc)
   end
 
   def has_assessment_by_assessor(assessor)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -9,10 +9,32 @@ class Submission < ActiveRecord::Base
   end
 
   def self.all_with_average_score
-    fields = ['id', 'candidate_name', 'candidate_email', 'email_text', 'zipfile', 'active', 'language_id', 'level_id', 'created_at', 'updated_at', 'source']
-    submission_fields = fields.map { |f| 'submissions.' + f }.join(',')
-    avg = ', round(avg(assessments.score) * 2) / 2 as average_score'
-    select(submission_fields + avg).joins('LEFT JOIN assessments ON (assessments.submission_id = submissions.id)').group(submission_fields).order(updated_at: :desc)
+    # fields = ['id', 'candidate_name', 'candidate_email', 'email_text', 'zipfile', 'active', 'language_id', 'level_id', 'created_at', 'updated_at', 'source']
+    # submission_fields = fields.map { |f| 'submissions.' + f }.join(',')
+    # avg = ', round(avg(assessments.score) * 2) / 2 as average_score'
+    # select(submission_fields + avg).joins('LEFT JOIN assessments ON (assessments.submission_id = submissions.id)').group(submission_fields).order(updated_at: :desc)
+    submissions_array = []
+    Submission.all.each do |submission|
+      submission_hash = submission.as_json
+      submission_hash[:average_score] = submission.average_published_assessment_score
+      submissions_array.push(submission_hash)
+      puts submission_hash
+    end
+    submissions_array
+  end
+
+  def average_published_assessment_score 
+    score_sum = 0
+    total_scores = 0
+    assessments.each do  |assessment|
+      if assessment.published 
+        score_sum += assessment.score
+        total_scores += 1
+      end
+    end
+    if total_scores != 0
+      score_sum / total_scores
+    end
   end
 
   def has_assessment_by_assessor(assessor)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -46,39 +46,41 @@ describe Submission do
   end
 
   describe '.all_with_average_score' do 
-    let(:submission)   { Submission.create() }
-    let!(:submission_2) { Submission.create() }
-    let!(:assessment1) {Assessment.create({submission: submission, score: 1})}
-    let!(:assessment2) {Assessment.create({submission: submission_2, score: 3})}
+    let(:submission0) { Submission.create() }
+    let(:submission1) { Submission.create() }
 
-    pending 'returns all submissions' do
-      expect(Submission.all_with_average_score).to match_array([submission.as_json, submission_2.as_json])
+    it 'returns all submissions' do
+      submission0
+      submission1
+      expect(Submission.all_with_average_score.length).to eq 2
     end
 
-    it 'calls average_published_assessment_score on each submission' do
-      submission
-      expect(submission).to receive(:average_published_assessment_score)
+    it 'returns all submissions has hashes with an additional average_score key' do
+      submission0
       Submission.all_with_average_score
+      expect(Submission.all_with_average_score.length).to eq 1
+      expect(Submission.all_with_average_score.first).to respond_to(:average_score)
     end
 
-    it 'returns a submission with an average score as a hash'
-    it 'returns all submissions as an array of hashes each with an average score'
+    it 'calculates the average assessment score for a submission to the nearest half-integer' do
+      Assessment.create({submission: submission0, score: 1})
+      Assessment.create({submission: submission0, score: 2})
+      Assessment.create({submission: submission0, score: 3})
+      Assessment.create({submission: submission0, score: 2})
+      Assessment.create({submission: submission0, score: 3})
+
+      expect(Submission.all_with_average_score.first.average_score).to eq 2.0
+    end
 
     it 'does not include scores for unpublished assesments in the average score' do
-      assessment_3 = Assessment.create(submission_id: submission.id, score: 3, published: false)
-      all_submissions = Submission.all_with_average_score
+      Assessment.create({submission: submission0, score: 1, published: false})
+      Assessment.create({submission: submission0, score: 2, published: false})
+      Assessment.create({submission: submission0, score: 2})
+      Assessment.create({submission: submission0, score: 3})
+      Assessment.create({submission: submission0, score: 2})
+      Assessment.create({submission: submission0, score: 3, published: false})
 
-      expect(all_submissions.first[:average_score].to_int).to eq 1
-    end
-  end
-
-  describe '#average_published_assessment_score' do 
-    it 'returns its own average assessment score' do 
-      submission      = Submission.create()
-      assessment      = Assessment.create(submission_id: submission.id, score: 1)
-      assessment_2    = Assessment.create(submission_id: submission.id, score: 3)
-    
-      expect(submission.average_published_assessment_score).to eq 2
+      expect(Submission.all_with_average_score.first.average_score).to eq 2.5
     end
   end
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -45,6 +45,43 @@ describe Submission do
     expect(submission.assessors.first).to eql(assessor)
   end
 
+  describe '.all_with_average_score' do 
+    let(:submission)   { Submission.create() }
+    let!(:submission_2) { Submission.create() }
+    let!(:assessment1) {Assessment.create({submission: submission, score: 1})}
+    let!(:assessment2) {Assessment.create({submission: submission_2, score: 3})}
+
+    pending 'returns all submissions' do
+      expect(Submission.all_with_average_score).to match_array([submission.as_json, submission_2.as_json])
+    end
+
+    it 'calls average_published_assessment_score on each submission' do
+      submission
+      expect(submission).to receive(:average_published_assessment_score)
+      Submission.all_with_average_score
+    end
+
+    it 'returns a submission with an average score as a hash'
+    it 'returns all submissions as an array of hashes each with an average score'
+
+    it 'does not include scores for unpublished assesments in the average score' do
+      assessment_3 = Assessment.create(submission_id: submission.id, score: 3, published: false)
+      all_submissions = Submission.all_with_average_score
+
+      expect(all_submissions.first[:average_score].to_int).to eq 1
+    end
+  end
+
+  describe '#average_published_assessment_score' do 
+    it 'returns its own average assessment score' do 
+      submission      = Submission.create()
+      assessment      = Assessment.create(submission_id: submission.id, score: 1)
+      assessment_2    = Assessment.create(submission_id: submission.id, score: 3)
+    
+      expect(submission.average_published_assessment_score).to eq 2
+    end
+  end
+
   describe '.create_from_json' do
     let(:file) { Tempfile.new('codetestbot-submission') }
     let(:email_text) { 'a new code test.' }


### PR DESCRIPTION
Mark helped me modify the SQL query made in the .all_with_average_score Submission class method so it only selects Assessments that are published. I was THIS CLOSE trying to use "&&" instead of "AND" like SQL prefers. 